### PR TITLE
Add OpenAPI documentation for Vendor API with endpoints for vendor management and order assignment

### DIFF
--- a/src/docs/vendor.yaml
+++ b/src/docs/vendor.yaml
@@ -1,0 +1,349 @@
+openapi: 3.0.0
+info:
+  title: Vendor API
+  version: 1.0.0
+  description: API for managing vendors and vendor-related operations
+  contact:
+    name: API Support
+    email: support@busy2shop.com
+  license:
+    name: proprietary
+servers:
+  - url: http://localhost:8000/api/v0
+    description: Development server
+
+components:
+  schemas:
+    VendorSettings:
+      type: object
+      properties:
+        isBlocked:
+          type: boolean
+          description: Whether the vendor is blocked
+        isDeactivated:
+          type: boolean
+          description: Whether the vendor account is deactivated
+
+    Market:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the market
+        name:
+          type: string
+          description: Name of the market
+        description:
+          type: string
+          description: Description of the market
+        ownerId:
+          type: string
+          format: uuid
+          description: ID of the vendor who owns the market
+
+    VendorResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the vendor
+        firstName:
+          type: string
+          description: Vendor's first name
+        lastName:
+          type: string
+          description: Vendor's last name
+        email:
+          type: string
+          format: email
+          description: Vendor's email address
+        status:
+          type: object
+          properties:
+            userType:
+              type: string
+              enum: [vendor]
+              description: Type of user
+            activated:
+              type: boolean
+              description: Whether the account is activated
+            emailVerified:
+              type: boolean
+              description: Whether the email is verified
+        settings:
+          $ref: '#/components/schemas/VendorSettings'
+        ownedMarkets:
+          type: array
+          items:
+            $ref: '#/components/schemas/Market'
+          description: Markets owned by the vendor
+        createdAt:
+          type: string
+          format: date-time
+          description: When the vendor account was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the vendor account was last updated
+
+    VendorStatsResponse:
+      type: object
+      properties:
+        totalOrders:
+          type: integer
+          description: Total number of orders handled by the vendor
+        completedOrders:
+          type: integer
+          description: Number of orders completed by the vendor
+        cancelledOrders:
+          type: integer
+          description: Number of orders cancelled by the vendor
+        pendingOrders:
+          type: integer
+          description: Number of orders currently pending or in progress
+        totalMarkets:
+          type: integer
+          description: Number of markets owned by the vendor
+
+    AssignOrderRequest:
+      type: object
+      properties:
+        vendorId:
+          type: string
+          format: uuid
+          description: ID of the vendor to assign the order to
+      required:
+        - vendorId
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+paths:
+  /vendor:
+    get:
+      summary: Get all vendors
+      tags:
+        - Vendor
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+          description: Page number for pagination
+        - in: query
+          name: size
+          schema:
+            type: integer
+          description: Number of items per page
+        - in: query
+          name: q
+          schema:
+            type: string
+          description: Search query for vendor name or email
+        - in: query
+          name: isActive
+          schema:
+            type: boolean
+          description: Filter by vendor active status
+        - in: query
+          name: lat
+          schema:
+            type: number
+            format: float
+          description: Latitude for location-based search
+        - in: query
+          name: lng
+          schema:
+            type: number
+            format: float
+          description: Longitude for location-based search
+        - in: query
+          name: distance
+          schema:
+            type: number
+            format: float
+          description: Search radius in kilometers (defaults to 5km)
+      responses:
+        '200':
+          description: Vendors retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: Vendors retrieved successfully
+                  data:
+                    type: object
+                    properties:
+                      vendors:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/VendorResponse'
+                      count:
+                        type: integer
+                        description: Total count of vendors
+                      totalPages:
+                        type: integer
+                        description: Total number of pages
+
+  /vendor/{id}:
+    get:
+      summary: Get a specific vendor's profile
+      tags:
+        - Vendor
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the vendor to retrieve
+      responses:
+        '200':
+          description: Vendor profile retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: Vendor profile retrieved successfully
+                  data:
+                    $ref: '#/components/schemas/VendorResponse'
+        '404':
+          description: Vendor not found
+
+  /vendor/{id}/stats:
+    get:
+      summary: Get statistics for a vendor
+      tags:
+        - Vendor
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the vendor to get statistics for (uses authenticated user ID if not provided)
+      responses:
+        '200':
+          description: Vendor statistics retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: Vendor stats retrieved successfully
+                  data:
+                    $ref: '#/components/schemas/VendorStatsResponse'
+        '403':
+          description: Forbidden - Not authorized to view this vendor's statistics
+        '404':
+          description: Vendor not found
+
+  /vendor/available/{shoppingListId}:
+    get:
+      summary: Get available vendors for an order
+      tags:
+        - Vendor
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: shoppingListId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the shopping list to find available vendors for
+      responses:
+        '200':
+          description: Available vendors retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: Available vendors retrieved successfully
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/VendorResponse'
+        '400':
+          description: Bad request - Shopping list ID is required
+        '403':
+          description: Forbidden - Not authorized to view available vendors
+        '404':
+          description: Shopping list not found
+
+  /vendor/assign/{orderId}:
+    post:
+      summary: Assign an order to a vendor
+      tags:
+        - Vendor
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: orderId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the order to assign
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignOrderRequest'
+      responses:
+        '200':
+          description: Order assigned to vendor successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: Order assigned to vendor successfully
+                  data:
+                    $ref: '#/components/schemas/VendorResponse'
+        '400':
+          description: Bad request - Vendor ID is required or order is not in pending status
+        '403':
+          description: Forbidden - Not authorized to assign orders
+        '404':
+          description: Order or vendor not found


### PR DESCRIPTION
This pull request introduces a new OpenAPI specification for the Vendor API. The changes include defining the API structure, endpoints, and data schemas for managing vendors and vendor-related operations.

Key changes:

### OpenAPI Specification:

* Added OpenAPI 3.0.0 specification for the Vendor API, including metadata such as title, version, description, contact information, and license. (`src/docs/vendor.yaml`)

### Components:

* Defined various schemas including `VendorSettings`, `Market`, `VendorResponse`, `VendorStatsResponse`, and `AssignOrderRequest` to standardize the data structures used in the API. (`src/docs/vendor.yaml`)

### Endpoints:

* Added multiple endpoints for vendor-related operations:
  * [`/vendor`](diffhunk://#diff-56ce6eb309d265271f131c7f7b07c7ad17ab601144f31c0ca780ab62950f4ce7R1-R349): Retrieve all vendors with support for pagination and filtering. (`src/docs/vendor.yaml`)
  * [`/vendor/{id}`](diffhunk://#diff-56ce6eb309d265271f131c7f7b07c7ad17ab601144f31c0ca780ab62950f4ce7R1-R349): Retrieve a specific vendor's profile. (`src/docs/vendor.yaml`)
  * [`/vendor/{id}/stats`](diffhunk://#diff-56ce6eb309d265271f131c7f7b07c7ad17ab601144f31c0ca780ab62950f4ce7R1-R349): Retrieve statistics for a specific vendor. (`src/docs/vendor.yaml`)
  * [`/vendor/available/{shoppingListId}`](diffhunk://#diff-56ce6eb309d265271f131c7f7b07c7ad17ab601144f31c0ca780ab62950f4ce7R1-R349): Retrieve available vendors for a specific order. (`src/docs/vendor.yaml`)
  * `/vendor/assign/{orderId}`: Assign an order to a vendor. (`src/docs