### PR TITLE
Update Swagger configuration to set dynamic base URL based on environment

### DIFF
--- a/src/swagger.config.ts
+++ b/src/swagger.config.ts
@@ -1,5 +1,16 @@
 import swaggerJsdoc from 'swagger-jsdoc';
 import * as path from 'node:path';
+import { PORT, NODE_ENV } from './utils/constants';
+
+// Determine the base URL based on environment
+const getBaseUrl = () => {
+    if (NODE_ENV === 'production') {
+        // For production, use the server's actual URL
+        return process.env.WEBSITE_URL ?? 'https://busy2shop-production.up.railway.app';
+    }
+    // For development, use localhost with the configured port
+    return `http://localhost:${PORT}`;
+};
 
 const options = {
     definition: {
@@ -15,8 +26,8 @@ const options = {
         },
         servers: [
             {
-                url: 'http://localhost:8000/api/v0',
-                description: 'Development server',
+                url: `${getBaseUrl()}/api/v0`,
+                description: `${NODE_ENV.charAt(0).toUpperCase() + NODE_ENV.slice(1)} server`,
             },
         ],
         components: {


### PR DESCRIPTION
This pull request includes changes to the `src/swagger.config.ts` file to dynamically determine the base URL for the Swagger API documentation based on the environment. The most important changes include introducing a function to get the base URL and modifying the server URL in the Swagger options.

Improvements to environment-based configuration:

* [`src/swagger.config.ts`](diffhunk://#diff-599e99753c668068bdcff2d62108bd51bcedd1e288f6e90e7258b177edeee073R3-R13): Added a `getBaseUrl` function to determine the base URL based on the environment, using the `NODE_ENV` and `PORT` constants.

Updates to Swagger configuration:

* [`src/swagger.config.ts`](diffhunk://#diff-599e99753c668068bdcff2d62108bd51bcedd1e288f6e90e7258b177edeee073L18-R30): Updated the server URL in the Swagger options to use the dynamically determined base URL and modified the server description to reflect the current environment.