### PR TITLE
Refactor Paystack API error handling to improve response management and add PaystackErrorResponse type

### DIFF
--- a/src/clients/paystack/paystack.types.ts
+++ b/src/clients/paystack/paystack.types.ts
@@ -1,4 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+export interface PaystackErrorResponse {
+    message?: string;
+    errors?: Record<string, string[]>;
+    status?: boolean;
+}
+
 export interface PaystackResponse<T> {
     status: boolean;
     message: string;


### PR DESCRIPTION
This pull request includes the addition of a new error response interface, refactoring error handling in the Paystack configuration service, and dynamically setting the base URL for the Swagger documentation.

Error handling improvements:

* [`src/clients/paystack/paystack.types.ts`](diffhunk://#diff-d09b53f798bd02ecadd82308772e00276b2ec7e53f5ad545bd32c4738a189b4fR2-R8): Added a new `PaystackErrorResponse` interface to standardize error responses from the Paystack API.
* [`src/clients/paystack/paystack.config.ts`](diffhunk://#diff-57b7ecf29ef36195e59c1eb015a17194a609970dd1fb136a34a4ceb56911e30cL4-R4): Refactored error handling in the `PaystackConfigService` class to use the new `PaystackErrorResponse` interface and handle different error status codes more effectively. [[1]](diffhunk://#diff-57b7ecf29ef36195e59c1eb015a17194a609970dd1fb136a34a4ceb56911e30cL4-R4) [[2]](diffhunk://#diff-57b7ecf29ef36195e59c1eb015a17194a609970dd1fb136a34a4ceb56911e30cL35-R55)
