### PR TITLE
Refactor rate limiter to use next() for error handling on too many attempts

### DIFF
--- a/src/middlewares/rateLimiter.ts
+++ b/src/middlewares/rateLimiter.ts
@@ -37,7 +37,7 @@ const rateLimiter = (secondsLimit: number, limitAmount: number, type: RateLimitT
 
             console.log('Sending suspicious email notification', attempts);
             // await suspiciousActivityEmail(email, attempts);
-            throw new BadRequestError('Too many attempts. Please try again later.');
+            return next(new BadRequestError('Too many attempts. Please try again later.'));
         } else {
             // Store attempt details in Redis hash
             await redisClient.hset(emailHashKey, incrResult.toString(), JSON.stringify({
@@ -87,7 +87,7 @@ const slidingWindowRateLimiter = (windowSizeInSeconds: number, limitAmount: numb
 
         if (requestCount >= limitAmount) {
             // Too many requests
-            throw new BadRequestError('Too many attempts. Please try again later.');
+            return next(new BadRequestError('Too many attempts. Please try again later.'));
         } else {
             // Add the current request timestamp to the sorted set
             await redisClient.zadd(emailTimestampsKey, currentTimestamp.toString(), currentTimestamp.toString());


### PR DESCRIPTION
This pull request includes changes to the `src/middlewares/rateLimiter.ts` file to improve error handling by passing errors to the next middleware instead of throwing them directly.

Error handling improvements:

* [`src/middlewares/rateLimiter.ts`](diffhunk://#diff-5a9ace969328c7dc93ec44e81cd38017499025b641fc68f501d1735b97cd7b2bL40-R40): Modified the `rateLimiter` function to return `next(new BadRequestError('Too many attempts. Please try again later.'))` instead of throwing the error directly.
* [`src/middlewares/rateLimiter.ts`](diffhunk://#diff-5a9ace969328c7dc93ec44e81cd38017499025b641fc68f501d1735b97cd7b2bL90-R90): Modified the `slidingWindowRateLimiter` function to return `next(new BadRequestError('Too many attempts. Please try again later.'))` instead of throwing the error directly.