### PR TITLE
Refactor import paths for consistency across auth module files

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -10,7 +10,7 @@ import UserService, { IDynamicQueryOptions } from '../services/user.service';
 import { AuthenticatedRequest } from '../middlewares/authMiddleware';
 import { WEBSITE_URL } from '../utils/constants';
 import { Transaction } from 'sequelize';
-import CloudinaryClientConfig from 'clients/cloudinary.config';
+import CloudinaryClientConfig from '../clients/cloudinary.config';
 
 export default class AuthController {
 

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -5,11 +5,9 @@ import User from '../models/user.model';
 import UserService from '../services/user.service';
 import { logger } from '../utils/logger';
 import { AuthUtil, TokenCacheUtil } from '../utils/token';
-// import AdminService from '../services/AdminServices/admin.service';
 import Admin from '../models/admin.model';
-import AdminService from 'services/AdminServices/admin.service';
-import { ADMIN_EMAIL } from 'utils/constants';
-// import { ADMIN_EMAIL } from '../utils/constants';
+import AdminService from '../services/AdminServices/admin.service';
+import { ADMIN_EMAIL } from '../utils/constants';
 
 
 export interface AuthenticatedRequest extends Request {

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,7 +1,7 @@
 import express, { Router } from 'express';
 import AuthController from '../controllers/auth.controller';
 import { basicAuth, AuthenticatedController } from '../middlewares/authMiddleware';
-import { uploadMiddleware, UploadType } from 'middlewares/uploadMiddleware';
+import { uploadMiddleware, UploadType } from '../middlewares/uploadMiddleware';
 // import { rateLimiter } from '../middlewares/rateLimiter';
 // import passport from 'passport';
 


### PR DESCRIPTION
This pull request includes several changes to import statements in various files to ensure consistency and correctness. The most important changes include updating import paths for `CloudinaryClientConfig`, `AdminService`, and `uploadMiddleware`.

Changes to import paths:

* [`src/controllers/auth.controller.ts`](diffhunk://#diff-ed5ba40d2434af19d0f9c9a372d570e291007a0c79d3ed1eaabeab69ce42c4d3L13-R13): Updated the import path for `CloudinaryClientConfig` to use a relative path.
* [`src/middlewares/authMiddleware.ts`](diffhunk://#diff-642accec5721eb6abe058055aa90898b5820a703d9a2cfc2589d22e44679d4beL8-R10): Updated the import path for `AdminService` to use a relative path and uncommented the import for `ADMIN_EMAIL` from `utils/constants`.
* [`src/routes/auth.routes.ts`](diffhunk://#diff-6620c64a6c55c03c2b0a0b8c5a2b5934c9575a3132d54c7f6bbbad3747a0013dL4-R4): Updated the import path for `uploadMiddleware` to use a relative path.