### PR TITLE
refactor: improve code comments for clarity and update variable declarations

### DIFF
--- a/src/clients/socket/index.config.ts
+++ b/src/clients/socket/index.config.ts
@@ -18,7 +18,7 @@ import { DecodedTokenData } from '../../utils/interface';
 import http from 'http';
 
 export default class SocketConfig {
-    private io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>;
+    private readonly io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>;
 
     constructor(server: http.Server) {
         this.io = new Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>(server, {
@@ -177,21 +177,21 @@ export default class SocketConfig {
                 logger.info(`User ${socket.data.user.id} left chat for order ${orderId}`);
             });
 
-            // Handle new message
+            // Handle the new message
             socket.on('send-message', async (data) => {
                 try {
                     const { orderId, message, imageUrl } = data;
                     const user = socket.data.user;
                     const roomName = `order:${orderId}`;
 
-                    // Check if chat is active
+                    // Check if the chat is active
                     const isChatActive = await ChatService.isChatActive(orderId);
                     if (!isChatActive) {
                         socket.emit('error', { message: 'Chat is not active for this order' });
                         return;
                     }
 
-                    // Save message to database
+                    // Save message to the database
                     const savedMessage = await ChatService.saveMessage({
                         orderId,
                         senderId: user.id,

--- a/src/controllers/Admin/admin.controller.ts
+++ b/src/controllers/Admin/admin.controller.ts
@@ -85,7 +85,7 @@ export default class AdminController {
     static async createAdmin(req: AdminAuthenticatedRequest, res: Response) {
         const { name, email, isSuperAdmin } = req.body;
 
-        if (req.isSuperAdmin === false) {
+        if (!req.isSuperAdmin) {
             throw new ForbiddenError('Only super admin can create new admins');
         }
 
@@ -136,7 +136,7 @@ export default class AdminController {
 
         const user = await UserService.viewSingleUser(userId);
         
-        // Check if user is already blocked
+        // Check if the user is already blocked
         if (user.settings.isBlocked) {
             throw new BadRequestError('User is already blocked');
         }
@@ -168,7 +168,7 @@ export default class AdminController {
 
         const user = await UserService.viewSingleUser(userId);
         
-        // Check if user is already unblocked
+        // Check if the user is already unblocked
         if (!user.settings.isBlocked) {
             throw new BadRequestError('User is not blocked');
         }
@@ -200,7 +200,7 @@ export default class AdminController {
 
         const user = await UserService.viewSingleUser(userId);
         
-        // Check if user is already deactivated
+        // Check if the user is already deactivated
         if (user.settings.isDeactivated) {
             throw new BadRequestError('User is already deactivated');
         }
@@ -223,7 +223,7 @@ export default class AdminController {
 
         const user = await UserService.viewSingleUser(userId);
         
-        // Check if user is already activated
+        // Check if the user is already activated
         if (!user.settings.isDeactivated) {
             throw new BadRequestError('User is already activated');
         }
@@ -260,7 +260,7 @@ export default class AdminController {
             queryParams.userType = userType;
         }
 
-        // Add search query if provided
+        // Add the search query if provided
         if (q) {
             queryParams.q = q as string;
         }


### PR DESCRIPTION
This pull request includes several changes aimed at improving code readability and ensuring consistency in comments and conditional checks. The most important changes include making the `io` property readonly in `SocketConfig`, updating comments for clarity, and simplifying conditional checks in the `AdminController`.

### Code readability and consistency improvements:

* [`src/clients/socket/index.config.ts`](diffhunk://#diff-085b54b7129f4d6f340cdd954dfcee452d6357e6f644c4820829891053867789L21-R21): Made the `io` property readonly in the `SocketConfig` class.
* [`src/clients/socket/index.config.ts`](diffhunk://#diff-085b54b7129f4d6f340cdd954dfcee452d6357e6f644c4820829891053867789L180-R194): Updated comments to improve clarity, such as changing "Handle new message" to "Handle the new message" and "Save message to database" to "Save message to the database".

### Simplification of conditional checks:

* [`src/controllers/Admin/admin.controller.ts`](diffhunk://#diff-a59e4192e747c05ba532850bd51c083660ad87bb60bdf50391d7b53bd6e2771bL88-R88): Simplified the conditional check for `isSuperAdmin` by using the shorthand `if (!req.isSuperAdmin)`.

### Additional comment updates for clarity:

* [`src/controllers/Admin/admin.controller.ts`](diffhunk://#diff-a59e4192e747c05ba532850bd51c083660ad87bb60bdf50391d7b53bd6e2771bL139-R139): Updated comments for better clarity, such as "Check if user is already blocked" to "Check if the user is already blocked" and similar changes for other user status checks. [[1]](diffhunk://#diff-a59e4192e747c05ba532850bd51c083660ad87bb60bdf50391d7b53bd6e2771bL139-R139) [[2]](diffhunk://#diff-a59e4192e747c05ba532850bd51c083660ad87bb60bdf50391d7b53bd6e2771bL171-R171) [[3]](diffhunk://#diff-a59e4192e747c05ba532850bd51c083660ad87bb60bdf50391d7b53bd6e2771bL203-R203) [[4]](diffhunk://#diff-a59e4192e747c05ba532850bd51c083660ad87bb60bdf50391d7b53bd6e2771bL226-R226) [[5]](diffhunk://#diff-a59e4192e747c05ba532850bd51c083660ad87bb60bdf50391d7b53bd6e2771bL263-R263)