### PR TITLE
refactor: update branding in email templates and server messages to reflect Busy2Shop

### DIFF
--- a/src/utils/Email/index.ts
+++ b/src/utils/Email/index.ts
@@ -73,7 +73,7 @@ export default class EmailService {
                 // Use Promise.all to wait for all emails to send
                 await Promise.all((options.postmarkInfo ?? []).map(async (recipient) => {
                     const mailOptions = {
-                        from: `Base Accounts<${EMAIL_HOST_ADDRESS}>`,
+                        from: `Busy2Shop Accounts<${EMAIL_HOST_ADDRESS}>`,
                         to: recipient.recipientEmail,
                         subject: options.subject,
                         html: options.html ? options.html : undefined,

--- a/src/utils/Email/templates/accountactivation.ts
+++ b/src/utils/Email/templates/accountactivation.ts
@@ -10,7 +10,7 @@ export const accountActivation = (otpCode: string, name: string) => {
                 <h1 style="color: #1e1e2d; margin: 10px 0; font-size: 35px; font-weight: 300; font-family: 'Rubik', sans-serif; text-transform: capitalize;">
                     Hi ${name}, <span style="text-transform: capitalize;"></span>
                 </h1>
-                <p style="color: #1e1e2d; font-size: 18px; margin: 10px 0;">Welcome to Base, we are excited to have you on board!</p>
+                <p style="color: #1e1e2d; font-size: 18px; margin: 10px 0;">Welcome to Busy2Shop, we are excited to have you on board!</p>
                 <p style="color: #1e1e2d; font-size: 16px; margin: 10px 0;">To complete your account activation, please use the following one-time passcode (OTP):</p>
             </div>
             <div style="margin-top: 15px;">

--- a/src/utils/Email/templates/container.ts
+++ b/src/utils/Email/templates/container.ts
@@ -5,7 +5,7 @@ export const container = (content: string) => {
 
 <head>
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
-    <title>Base</title>
+    <title>Busy2Shop</title>
     <meta name="description" content="Email Template Container.">
     <style type="text/css">
         a:hover {
@@ -33,10 +33,10 @@ export const container = (content: string) => {
                     </tr>
                     <tr>
                         <td style="text-align: center; color: #333;">
-                            <p>Thank you for choosing Base</p>
-                            <p>Best regards,<br>The Base Team</p>
+                            <p>Thank you for choosing Busy2Shop</p>
+                            <p>Best regards,<br>The Busy2Shop Team</p>
                             <p style="font-size: 18px; color: #F04950; line-height: 18px; margin: 0 0 0;">&copy;
-                                <strong> Base LTD 2024 </strong>
+                                <strong> Busy2Shop LTD 2025 </strong>
                             </p>
                         </td>
                     </tr>

--- a/src/utils/Email/templates/forgotpassword.ts
+++ b/src/utils/Email/templates/forgotpassword.ts
@@ -10,7 +10,7 @@ export const forgotPassword = ({ link, name }: { link: string, name: string }) =
                 <h1 style="color: #1e1e2d; margin: 10px 0; font-size: 35px; font-weight: 300; text-transform: capitalize;">
                     Hi ${name},
                 </h1>
-                <p style="color: #1e1e2d; font-size: 18px; margin: 10px 0;">We received a request to reset your password for your Base account.</p>
+                <p style="color: #1e1e2d; font-size: 18px; margin: 10px 0;">We received a request to reset your password for your Busy2Shop account.</p>
                 <p style="color: #1e1e2d; font-size: 16px; margin: 10px 0;">To reset your password, please click the link below:</p>
             </div>
             <div style="margin-top: 15px;">

--- a/src/views/serverHealthCheck.ts
+++ b/src/views/serverHealthCheck.ts
@@ -7,7 +7,7 @@ import { serverHealth } from './serverhealth';
 export async function getServerHealth(req: Request, res: Response): Promise<void> {
     const data = {
         serverStatus: 'success',
-        message: `Welcome to Base ${process.env.NODE_ENV} server`,
+        message: `Welcome to Busy2Shop ${process.env.NODE_ENV} server`,
         documentation: DOCUMENTATION_URL,
         client: WEBSITE_URL,
         admin: 'www.twitter.com',


### PR DESCRIPTION
This pull request includes several changes to update branding from "Base" to "Busy2Shop" across various email templates and a server health check message. The most important changes include modifications to email templates and server health check messages to reflect the new branding.

Branding updates:

* [`src/utils/Email/index.ts`](diffhunk://#diff-303efa3f52446ff473a71f412d6f8e7128bb576d7e8c291b2d50ce3b7f4e085dL76-R76): Changed the "from" field in email options from "Base Accounts" to "Busy2Shop Accounts".
* [`src/utils/Email/templates/accountactivation.ts`](diffhunk://#diff-8cdc3f744d7afa96594d67307488166e62a039eb5a4d1dbecbda86a8200de174L13-R13): Updated the welcome message to reflect "Busy2Shop" instead of "Base".
* [`src/utils/Email/templates/container.ts`](diffhunk://#diff-cfaba788ef95ac2cba58c1524fe04caba005c591de7e06e3306f9984c2f0fd81L8-R8): Changed the title and thank you message to "Busy2Shop" and updated the company name and year in the footer. [[1]](diffhunk://#diff-cfaba788ef95ac2cba58c1524fe04caba005c591de7e06e3306f9984c2f0fd81L8-R8) [[2]](diffhunk://#diff-cfaba788ef95ac2cba58c1524fe04caba005c591de7e06e3306f9984c2f0fd81L36-R39)
* [`src/utils/Email/templates/forgotpassword.ts`](diffhunk://#diff-964715ea39ce9e9f481d3bcd2e3bb41dbfb4ad7aba96ed739b2e1aa0313b7f3bL13-R13): Updated the password reset message to refer to "Busy2Shop" instead of "Base".
* [`src/views/serverHealthCheck.ts`](diffhunk://#diff-3da91c63f86c6945ce401b3d8de412fdcf1e1aa3125b71bdeee9748efeee7851L10-R10): Modified the server health check message to welcome users to the "Busy2Shop" server instead of the "Base" server.